### PR TITLE
Raise OperationalError for ConnectionWrite error

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -955,7 +955,7 @@ def ctrl_err(ht, h, val_ret, ansi):
                 raise IntegrityError(state,err_text)
             elif state == raw_s('0A000'):
                 raise NotSupportedError(state,err_text)
-            elif state in (raw_s('HYT00'),raw_s('HYT01')):
+            elif state in (raw_s('HYT00'),raw_s('HYT01'),raw_s('01000')):
                 raise OperationalError(state,err_text)
             elif state[:2] in (raw_s('IM'),raw_s('HY')):
                 raise Error(state,err_text)


### PR DESCRIPTION
As stated in the DB API 2.0, an OperationalError Exception is raised in
case of unexpected disconnections.

To test this PR, open a connection, restart the db engine (i.e. sql
server) and try to use the connection, you should get the following
message
'''
u'[01000] [Microsoft][ODBC SQL Server Driver][DBNETLIB]ConnectionWrite
(send()).'
'''
